### PR TITLE
fix(repo): skip serializing some empty fields

### DIFF
--- a/anni-repo/src/models/album.rs
+++ b/anni-repo/src/models/album.rs
@@ -11,6 +11,7 @@ use crate::prelude::*;
 pub struct Album {
     #[serde(rename = "album")]
     info: AlbumInfo,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     discs: Vec<Disc>,
 }
 


### PR DESCRIPTION
- when `Album.discs` is empty
fix a `ValueAfterTable` error
- when `Track.artist` is empty
avoid generating lots of `artist = ""`