### PR TITLE
feat(common): don't use nightly features

### DIFF
--- a/anni-common/src/fs.rs
+++ b/anni-common/src/fs.rs
@@ -286,6 +286,10 @@ where
     Ok(())
 }
 
+/// Checks raw os error code of `error`.
+///
+/// Returns true if the code is [`EXDEV`](https://github.com/rust-lang/rust/blob/master/library/std/src/sys/unix/mod.rs#L284) on unix
+/// or [`ERROR_NOT_SAME_DEVICE`](https://github.com/rust-lang/rust/blob/master/library/std/src/sys/windows/mod.rs#L114) on windows
 fn is_cross_device_error(error: &io::Error) -> bool {
     let code = error.raw_os_error();
     #[cfg(windows)]

--- a/anni-common/src/fs.rs
+++ b/anni-common/src/fs.rs
@@ -297,5 +297,8 @@ fn is_cross_device_error(error: &io::Error) -> bool {
         code == Some(18)
     }
     #[cfg(all(not(windows), not(unix)))]
-    compile_error!("unsupported platform")
+    {
+        // unsupported platform
+        false
+    }
 }

--- a/anni-common/src/lib.rs
+++ b/anni-common/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(io_error_more)]
-
 pub mod decode;
 pub mod diagnostic;
 pub mod encode;


### PR DESCRIPTION
Check raw os error instead of checking unstable ErrorKind variants.
This commit is tested on windows and needs testing on different os.