### PR TITLE
fix(anni-playback): add timeout on writing audio

### DIFF
--- a/anni-playback/src/utils/blocking_rb.rs
+++ b/anni-playback/src/utils/blocking_rb.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <https://www.gnu.org/licenses/>.
 
-use std::sync::{atomic::AtomicUsize, Arc, Condvar, Mutex};
+use std::{
+    sync::{atomic::AtomicUsize, Arc, Condvar, Mutex},
+    time::Duration,
+};
 
 /// Provides the producer methods of the ring buffer.
 #[derive(Clone)]
@@ -102,8 +105,14 @@ impl<T: Copy + Clone + Default + Sync + Send> BlockingRb<T, Producer> {
             // Wait for the event to tell us that there free space
             // available or that the operation should be cancelled.
             let (mutex, cvar) = &*self.producer_events;
-            let mut event = mutex.lock().unwrap();
-            event = cvar.wait(event).unwrap();
+            let event = mutex.lock().unwrap();
+            let (event, timeout) = cvar
+                .wait_timeout(event, Duration::from_millis(500))
+                .unwrap();
+
+            if timeout.timed_out() {
+                return None;
+            }
 
             match *event {
                 Event::CancelWrite => return None,

--- a/anni-playback/src/utils/blocking_rb.rs
+++ b/anni-playback/src/utils/blocking_rb.rs
@@ -106,6 +106,7 @@ impl<T: Copy + Clone + Default + Sync + Send> BlockingRb<T, Producer> {
             // available or that the operation should be cancelled.
             let (mutex, cvar) = &*self.producer_events;
             let event = mutex.lock().unwrap();
+            // todo: solve remaining problems in https://github.com/ProjectAnni/anni/pull/41
             let (event, timeout) = cvar
                 .wait_timeout(event, Duration::from_millis(500))
                 .unwrap();


### PR DESCRIPTION
I have found various issues related to the deadlock `BlockingRb::write`, which waits on a condvar endlessly under certain circumstances (audio interruption, and maybe device change), blocking the decoder thread.

This pr adds a timeout so the write will be cancelled if it waits too long. As a result, audio interruption is handled correctly.

tested on: https://github.com/snylonue/annix/actions/runs/8410385256

## Remaining problems
- [ ] What is the root cause of the deadlock?
- [ ] Is 500ms a proper timeout? Does it affect the quality of playback?