### PR TITLE
fix(anni-playback): fix compilation on non-windows platform

### DIFF
--- a/anni-playback/src/cpal_output.rs
+++ b/anni-playback/src/cpal_output.rs
@@ -159,7 +159,7 @@ impl CpalOutputStream {
         }
     }
 
-    fn get_config(_spec: SignalSpec) -> anyhow::Result<(Device, StreamConfig)> {
+    fn get_config(spec: SignalSpec) -> anyhow::Result<(Device, StreamConfig)> {
         let host = cpal::default_host();
         let device = host
             .default_output_device()

--- a/anni-playback/src/cpal_output.rs
+++ b/anni-playback/src/cpal_output.rs
@@ -159,7 +159,9 @@ impl CpalOutputStream {
         }
     }
 
-    fn get_config(spec: SignalSpec) -> anyhow::Result<(Device, StreamConfig)> {
+    fn get_config(
+        #[cfg_attr(target_os = "windows", allow(unused))] spec: SignalSpec,
+    ) -> anyhow::Result<(Device, StreamConfig)> {
         let host = cpal::default_host();
         let device = host
             .default_output_device()


### PR DESCRIPTION
`spec` is considered as an unused variable by mistake in `103341`