### PR TITLE
fix(anni-playback): pad 0 to output stream

### DIFF
--- a/anni-playback/src/cpal_output.rs
+++ b/anni-playback/src/cpal_output.rs
@@ -94,6 +94,10 @@ impl CpalOutputStream {
                         data[0..written]
                             .iter_mut()
                             .for_each(|s| *s *= BASE_VOLUME * *controls.volume());
+
+                        data[written..].fill(0.);
+                    } else {
+                        data.fill(0.);
                     }
                 }
             },


### PR DESCRIPTION
fixes noise when there is not enough audio data