### PR TITLE
fix(playback): pause rather than stop before open

### DIFF
--- a/anni-playback/src/player.rs
+++ b/anni-playback/src/player.rs
@@ -83,7 +83,7 @@ impl AnniPlayer {
     pub fn open(&self, track: TrackIdentifier, quality: AudioQuality) -> anyhow::Result<()> {
         log::info!("loading track: {track}");
 
-        self.controls.stop();
+        self.controls.pause();
 
         let provider = self.provider.read().unwrap();
 


### PR DESCRIPTION
I made this change previously when moving anni-player into anni-playback as an attempt to fix occasional incorrect offsets when opening a track.

However, it does not work and probably causes a bug that the first track in playing queue is skipped.