### PR TITLE
feat(playback): use content-length to validate cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,8 @@ dependencies = [
  "ratatui",
  "reqwest 0.12.7",
  "rubato",
+ "serde",
+ "serde_json",
  "symphonia",
  "symphonia-core",
  "thiserror",

--- a/anni-playback/Cargo.toml
+++ b/anni-playback/Cargo.toml
@@ -33,6 +33,8 @@ log.workspace = true
 anni-provider = { version = "0.3.1", path = "../anni-provider", default-features = false, features = ["priority"] }
 anni-common = { version = "0.2", path = "../anni-common" }
 thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 # used by tui example

--- a/anni-playback/src/sources/cached_http/cache.rs
+++ b/anni-playback/src/sources/cached_http/cache.rs
@@ -88,7 +88,7 @@ impl CacheStore {
 
     pub fn store_info(&self, track: RawTrackIdentifier, kind: &str, value: &str) -> io::Result<()> {
         let path = {
-            let mut p = self.loaction_of(track);
+            let mut p = self.loaction_of(track.copied());
             p.set_extension("info");
             p
         };
@@ -107,6 +107,7 @@ impl CacheStore {
             .open(path)?;
 
         for (kind, value) in info {
+            log::debug!("{track}: stored {kind} = {value}");
             writeln!(writer, "{kind}:{value}")?;
         }
 

--- a/anni-playback/src/sources/cached_http/mod.rs
+++ b/anni-playback/src/sources/cached_http/mod.rs
@@ -202,12 +202,18 @@ impl CachedAnnilSource {
                     .inspect_err(|e| log::warn!("{e}"))
                     .ok()
             })
-            .map(|response| {
-                let duration = response
-                    .headers()
-                    .get("X-Duration-Seconds")
-                    .and_then(|v| v.to_str().ok().and_then(|dur| dur.parse().ok()));
-                (response.url().clone(), duration)
+            .map(|r| {
+                let (url, headers) = (r.url(), r.headers());
+                let parse_header = |key| headers.get(key).and_then(|v| v.to_str().ok());
+                let duration = parse_header("X-Duration-Seconds").and_then(|v| v.parse().ok());
+                if let Some(content_length) = r.content_length() {
+                    let _ = cache_store.store_info(
+                        cloned_track.inner.copied(),
+                        "content-length",
+                        &content_length.to_string(),
+                    );
+                }
+                (url.clone(), duration)
             });
 
         CachedHttpSource::new(track, || source.next(), cache_store, client, buffer_signal).map(Self)

--- a/anni-playback/src/sources/cached_http/mod.rs
+++ b/anni-playback/src/sources/cached_http/mod.rs
@@ -210,7 +210,7 @@ impl CachedAnnilSource {
                     let _ = cache_store.store_info(
                         cloned_track.inner.copied(),
                         "content-length",
-                        &content_length.to_string(),
+                        content_length,
                     );
                 }
                 (url.clone(), duration)


### PR DESCRIPTION
The content-length is stored before downloading the audio.

Currently, if content-length is not found, we will fallback to decoder to validate the cache.